### PR TITLE
Update R documentation to include `maxFragmentLength` param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .DS_Store
+.ipynb_checkpoints/
+Rplots.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Roxygen: list(markdown = TRUE)
 License: GPL (>= 2)
 LinkingTo: Rcpp
 LazyData: TRUE
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 Imports:
     Rcpp (>= 0.12.16),

--- a/R/ArrowRead.R
+++ b/R/ArrowRead.R
@@ -67,6 +67,7 @@ getFragmentsFromProject <- function(
 #' @param cellNames A character vector indicating the cell names of a subset of cells from which fragments whould be extracted.
 #' This allows for extraction of fragments from only a subset of selected cells. By default, this function will extract all cells
 #' from the provided ArrowFile using `getCellNames()`.
+#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain when filtering
 #' @param verbose A boolean value indicating whether to use verbose output during execution of this function. Can be set to `FALSE` for a cleaner output.
 #' @param logFile The path to a file to be used for logging ArchR output.
 #' @export

--- a/R/GroupCoverages.R
+++ b/R/GroupCoverages.R
@@ -14,7 +14,7 @@
 #' @param maxReplicates The maximum number of pseudo-bulk replicates to be generated.
 #' @param sampleRatio The fraction of the total cells that can be sampled to generate any given pseudo-bulk replicate.
 #' @param kmerLength The length of the k-mer used for estimating Tn5 bias.
-#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain
+#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain when filtering
 #' @param threads The number of threads to be used for parallel computing.
 #' @param returnGroups A boolean value that indicates whether to return sample-guided cell-groupings without creating coverages.
 #' This is used mainly in `addReproduciblePeakSet()` when MACS2 is not being used to call peaks but rather peaks are called from a

--- a/R/GroupCoverages.R
+++ b/R/GroupCoverages.R
@@ -14,6 +14,7 @@
 #' @param maxReplicates The maximum number of pseudo-bulk replicates to be generated.
 #' @param sampleRatio The fraction of the total cells that can be sampled to generate any given pseudo-bulk replicate.
 #' @param kmerLength The length of the k-mer used for estimating Tn5 bias.
+#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain
 #' @param threads The number of threads to be used for parallel computing.
 #' @param returnGroups A boolean value that indicates whether to return sample-guided cell-groupings without creating coverages.
 #' This is used mainly in `addReproduciblePeakSet()` when MACS2 is not being used to call peaks but rather peaks are called from a

--- a/R/MatrixFeatures.R
+++ b/R/MatrixFeatures.R
@@ -17,7 +17,7 @@
 #' @param parallelParam A list of parameters to be passed for biocparallel/batchtools parallel computing.
 #' @param force A boolean value indicating whether to force the matrix indicated by `matrixName` to be overwritten if it already exists in the `input`.
 #' @param logFile The path to a file to be used for logging ArchR output.
-#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain
+#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain when filtering
 #' @export
 addFeatureMatrix <- function(
   input = NULL,
@@ -107,6 +107,7 @@ addFeatureMatrix <- function(
 #'
 #' @param ArchRProj An `ArchRProject` object.
 #' @param ceiling The maximum counts per feature allowed. This is used to prevent large biases in peak counts.
+#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain when filtering
 #' @param binarize A boolean value indicating whether the peak matrix should be binarized prior to storage. This can be useful
 #' for downstream analyses when working with insertion counts.
 #' @param verbose A boolean value that determines whether standard output includes verbose sections.

--- a/R/MatrixFeatures.R
+++ b/R/MatrixFeatures.R
@@ -17,6 +17,7 @@
 #' @param parallelParam A list of parameters to be passed for biocparallel/batchtools parallel computing.
 #' @param force A boolean value indicating whether to force the matrix indicated by `matrixName` to be overwritten if it already exists in the `input`.
 #' @param logFile The path to a file to be used for logging ArchR output.
+#' @param maxFragmentLength An integer or Inf that describes the max fragment length to retain
 #' @export
 addFeatureMatrix <- function(
   input = NULL,

--- a/man/addFeatureMatrix.Rd
+++ b/man/addFeatureMatrix.Rd
@@ -40,7 +40,7 @@ downstream analyses when working with insertion counts.}
 
 \item{logFile}{The path to a file to be used for logging ArchR output.}
 
-\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain}
+\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain when filtering}
 }
 \description{
 This function for each sample will independently compute counts for each feature per cell in the provided ArchRProject or set of ArrowFiles.

--- a/man/addFeatureMatrix.Rd
+++ b/man/addFeatureMatrix.Rd
@@ -14,7 +14,8 @@ addFeatureMatrix(
   threads = getArchRThreads(),
   parallelParam = NULL,
   force = TRUE,
-  logFile = createLogFile("addFeatureMatrix")
+  logFile = createLogFile("addFeatureMatrix"),
+  maxFragmentLength = Inf
 )
 }
 \arguments{
@@ -38,6 +39,8 @@ downstream analyses when working with insertion counts.}
 \item{force}{A boolean value indicating whether to force the matrix indicated by \code{matrixName} to be overwritten if it already exists in the \code{input}.}
 
 \item{logFile}{The path to a file to be used for logging ArchR output.}
+
+\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain}
 }
 \description{
 This function for each sample will independently compute counts for each feature per cell in the provided ArchRProject or set of ArrowFiles.

--- a/man/addGroupCoverages.Rd
+++ b/man/addGroupCoverages.Rd
@@ -46,7 +46,7 @@ of excessively large files which would negatively impact memory requirements.}
 
 \item{kmerLength}{The length of the k-mer used for estimating Tn5 bias.}
 
-\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain}
+\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain when filtering}
 
 \item{threads}{The number of threads to be used for parallel computing.}
 

--- a/man/addGroupCoverages.Rd
+++ b/man/addGroupCoverages.Rd
@@ -15,6 +15,7 @@ addGroupCoverages(
   maxReplicates = 5,
   sampleRatio = 0.8,
   kmerLength = 6,
+  maxFragmentLength = Inf,
   threads = getArchRThreads(),
   returnGroups = FALSE,
   parallelParam = NULL,
@@ -44,6 +45,8 @@ of excessively large files which would negatively impact memory requirements.}
 \item{sampleRatio}{The fraction of the total cells that can be sampled to generate any given pseudo-bulk replicate.}
 
 \item{kmerLength}{The length of the k-mer used for estimating Tn5 bias.}
+
+\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain}
 
 \item{threads}{The number of threads to be used for parallel computing.}
 

--- a/man/addPeakMatrix.Rd
+++ b/man/addPeakMatrix.Rd
@@ -21,6 +21,8 @@ addPeakMatrix(
 
 \item{ceiling}{The maximum counts per feature allowed. This is used to prevent large biases in peak counts.}
 
+\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain when filtering}
+
 \item{binarize}{A boolean value indicating whether the peak matrix should be binarized prior to storage. This can be useful
 for downstream analyses when working with insertion counts.}
 

--- a/man/addPeakMatrix.Rd
+++ b/man/addPeakMatrix.Rd
@@ -7,6 +7,7 @@
 addPeakMatrix(
   ArchRProj = NULL,
   ceiling = 4,
+  maxFragmentLength = Inf,
   binarize = FALSE,
   verbose = TRUE,
   threads = getArchRThreads(),

--- a/man/getFragmentsFromArrow.Rd
+++ b/man/getFragmentsFromArrow.Rd
@@ -8,6 +8,7 @@ getFragmentsFromArrow(
   ArrowFile = NULL,
   chr = NULL,
   cellNames = NULL,
+  maxFragmentLength = Inf,
   verbose = TRUE,
   logFile = createLogFile("getFragmentsFromArrow")
 )

--- a/man/getFragmentsFromArrow.Rd
+++ b/man/getFragmentsFromArrow.Rd
@@ -22,6 +22,8 @@ getFragmentsFromArrow(
 This allows for extraction of fragments from only a subset of selected cells. By default, this function will extract all cells
 from the provided ArrowFile using \code{getCellNames()}.}
 
+\item{maxFragmentLength}{An integer or Inf that describes the max fragment length to retain when filtering}
+
 \item{verbose}{A boolean value indicating whether to use verbose output during execution of this function. Can be set to \code{FALSE} for a cleaner output.}
 
 \item{logFile}{The path to a file to be used for logging ArchR output.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // rowCorCpp
 Rcpp::NumericVector rowCorCpp(IntegerVector idxX, IntegerVector idxY, Rcpp::NumericMatrix X, Rcpp::NumericMatrix Y);
 RcppExport SEXP _ArchR_rowCorCpp(SEXP idxXSEXP, SEXP idxYSEXP, SEXP XSEXP, SEXP YSEXP) {


### PR DESCRIPTION
Updated documentation for several functions using the added` maxFragmentLength` parameter. Addresses confusion when calling these functions, mentioned (here)[https://github.com/dpeerlab/SEACells/issues/35] 